### PR TITLE
Improve SHAP and DAG visual explanations

### DIFF
--- a/src/components/visualizations/SHAPVisual.tsx
+++ b/src/components/visualizations/SHAPVisual.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { VisualCard } from './VisualCard';
 import { TrendingUp, TrendingDown } from 'lucide-react';
 
@@ -9,8 +9,45 @@ interface SHAPVisualProps {
 export const SHAPVisual: React.FC<SHAPVisualProps> = ({ shapData }) => {
   if (!shapData) return null;
 
+  const featureMeta: Record<string, { group: string; desc: string; why: string }> = {
+    'Flight Deviation': {
+      group: 'Flight Data',
+      desc: 'Difference between expected and actual flight path.',
+      why: 'High deviation is often observed during evasive manoeuvres.'
+    },
+    'Speed Increase': {
+      group: 'Flight Data',
+      desc: 'Current speed relative to filed flight plan.',
+      why: 'Rapid acceleration may indicate intentional course change.'
+    },
+    'ATC Non-Response': {
+      group: 'Communications',
+      desc: 'Time since last radio contact with controllers.',
+      why: 'Lack of response suggests potential hostile intent.'
+    },
+    'Geographic Vector': {
+      group: 'Environmental',
+      desc: 'Approach direction with respect to sensitive locations.',
+      why: 'Certain approach vectors correlate with threat patterns.'
+    },
+    'Time of Day': {
+      group: 'Environmental',
+      desc: 'Local time during observation.',
+      why: 'Events at night have historically higher risk.'
+    }
+  };
+
   const features = Object.entries(shapData).sort(([, a], [, b]) => Math.abs(b) - Math.abs(a));
   const maxAbsValue = Math.max(...features.map(([, v]) => Math.abs(v)));
+
+  const grouped = features.reduce<Record<string, Array<[string, number]>>>((acc, cur) => {
+    const group = featureMeta[cur[0]]?.group || 'Other';
+    if (!acc[group]) acc[group] = [];
+    acc[group].push(cur);
+    return acc;
+  }, {});
+
+  const [active, setActive] = useState<string | null>(null);
 
   return (
     <VisualCard>
@@ -20,41 +57,62 @@ export const SHAPVisual: React.FC<SHAPVisualProps> = ({ shapData }) => {
           SHAP Feature Importance
         </h3>
       </div>
-      
-      <div className="space-y-4">
-        {features.map(([feature, value]) => (
-          <div key={feature} className="group">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">
-                {feature}
-              </span>
-              <div className="flex items-center">
-                {value > 0 ? (
-                  <TrendingUp className="w-4 h-4 text-green-400 mr-1" />
-                ) : (
-                  <TrendingDown className="w-4 h-4 text-red-400 mr-1" />
-                )}
-                <span className={`text-sm font-bold ${value > 0 ? 'text-green-400' : 'text-red-400'}`}>
-                  {value.toFixed(2)}
-                </span>
-              </div>
-            </div>
-            
-            <div className="relative bg-slate-700/50 rounded-full h-3 overflow-hidden">
+
+      <div className="space-y-6">
+        {Object.entries(grouped).map(([group, groupFeatures]) => (
+          <div key={group} className="space-y-4">
+            <h4 className="text-sm font-semibold text-gray-400 border-b border-slate-600/50 pb-1 mb-1">
+              {group}
+            </h4>
+            {groupFeatures.map(([feature, value]) => (
               <div
-                style={{ width: `${(Math.abs(value) / maxAbsValue) * 100}%` }}
-                className={`
-                  h-full transition-all duration-500 ease-out
-                  ${value > 0 
-                    ? 'bg-gradient-to-r from-green-500 to-green-400' 
-                    : 'bg-gradient-to-r from-red-500 to-red-400'
-                  }
-                `}
-              />
-            </div>
+                key={feature}
+                className="group cursor-pointer"
+                onMouseEnter={() => setActive(feature)}
+                onMouseLeave={() => setActive(null)}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">
+                    {feature}
+                  </span>
+                  <div className="flex items-center">
+                    {value > 0 ? (
+                      <TrendingUp className="w-4 h-4 text-green-400 mr-1" />
+                    ) : (
+                      <TrendingDown className="w-4 h-4 text-red-400 mr-1" />
+                    )}
+                    <span className={`text-sm font-bold ${value > 0 ? 'text-green-400' : 'text-red-400'}`}>
+                      {value.toFixed(2)}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="relative bg-slate-700/50 rounded-full h-3 overflow-hidden">
+                  <div
+                    style={{ width: `${(Math.abs(value) / maxAbsValue) * 100}%` }}
+                    className={`
+                      h-full transition-all duration-500 ease-out
+                      ${value > 0
+                        ? 'bg-gradient-to-r from-green-500 to-green-400'
+                        : 'bg-gradient-to-r from-red-500 to-red-400'
+                      }
+                    `}
+                  />
+                </div>
+              </div>
+            ))}
           </div>
         ))}
       </div>
+
+      {active && (
+        <div className="mt-6 p-4 rounded-lg bg-slate-800/70 border border-slate-600/50 text-sm space-y-1">
+          <p className="text-teal-300 font-semibold">{active}</p>
+          <p className="text-gray-300">{featureMeta[active]?.desc}</p>
+          <p className="text-gray-400 text-xs">{featureMeta[active]?.why}</p>
+          <p className="text-gray-500 text-xs">Importance score: {shapData[active]?.toFixed(2)}</p>
+        </div>
+      )}
     </VisualCard>
   );
 };


### PR DESCRIPTION
## Summary
- add feature metadata and grouping to SHAP visuals
- show interactive tooltip panel on feature hover
- colour code DAG nodes by group and display legend
- show node explanations on hover in DAG view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685c72639fd08328a51a2f09af7672fe